### PR TITLE
Add harvesting provenance

### DIFF
--- a/config/delta-producer/worship/export.json
+++ b/config/delta-producer/worship/export.json
@@ -24,6 +24,7 @@
         "http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan",
         "http://data.vlaanderen.be/ns/mandaat#status",
         "http://www.w3.org/2002/07/owl#sameAs",
+        "http://www.w3.org/ns/prov#wasGeneratedBy",
         "http://data.lblod.info/vocabularies/contacthub/startdatum",
         "http://data.lblod.info/vocabularies/contacthub/eindedatum",
         "http://www.w3.org/ns/org#heldBy"
@@ -35,6 +36,7 @@
       "properties": [
         "http://mu.semte.ch/vocabularies/core/uuid",
         "http://www.w3.org/2002/07/owl#sameAs",
+        "http://www.w3.org/ns/prov#wasGeneratedBy",
         "http://www.w3.org/ns/org#holds",
         "http://data.lblod.info/vocabularies/erediensten/financiering",
         "http://www.w3.org/ns/org#siteAddress",
@@ -51,6 +53,7 @@
       "properties": [
         "http://mu.semte.ch/vocabularies/core/uuid",
         "http://www.w3.org/2002/07/owl#sameAs",
+        "http://www.w3.org/ns/prov#wasGeneratedBy",
         "http://xmlns.com/foaf/0.1/familyName",
         "http://xmlns.com/foaf/0.1/name",
         "https://data.vlaanderen.be/ns/persoon#gebruikteVoornaam",
@@ -69,6 +72,7 @@
       "properties": [
         "http://mu.semte.ch/vocabularies/core/uuid",
         "http://www.w3.org/2002/07/owl#sameAs",
+        "http://www.w3.org/ns/prov#wasGeneratedBy",
         "https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator",
         "http://www.w3.org/2004/02/skos/core#notation",
         "http://purl.org/dc/terms/creator",
@@ -82,6 +86,7 @@
       "properties": [
         "http://mu.semte.ch/vocabularies/core/uuid",
         "http://www.w3.org/2002/07/owl#sameAs",
+        "http://www.w3.org/ns/prov#wasGeneratedBy",
         "https://data.vlaanderen.be/ns/generiek#lokaleIdentificator",
         "https://data.vlaanderen.be/ns/generiek#naamruimte",
         "https://data.vlaanderen.be/ns/generiek#versieIdentificator"
@@ -93,6 +98,7 @@
       "properties": [
         "http://mu.semte.ch/vocabularies/core/uuid",
         "http://www.w3.org/2002/07/owl#sameAs",
+        "http://www.w3.org/ns/prov#wasGeneratedBy",
         "https://data.vlaanderen.be/ns/persoon#datum"
       ]
     },
@@ -102,6 +108,7 @@
       "properties": [
         "http://mu.semte.ch/vocabularies/core/uuid",
         "http://www.w3.org/2002/07/owl#sameAs",
+        "http://www.w3.org/ns/prov#wasGeneratedBy",
         "http://www.w3.org/2006/vcard/ns#honorific-prefix",
         "http://www.w3.org/ns/locn#address",
         "http://schema.org/hoursAvailable",
@@ -124,6 +131,7 @@
       "properties": [
         "http://mu.semte.ch/vocabularies/core/uuid",
         "http://www.w3.org/2002/07/owl#sameAs",
+        "http://www.w3.org/ns/prov#wasGeneratedBy",
         "http://www.w3.org/ns/locn#location",
         "http://www.w3.org/ns/locn#geographicName",
         "http://www.w3.org/ns/locn#seeAlso",

--- a/config/job-controller/config.json
+++ b/config/job-controller/config.json
@@ -33,18 +33,23 @@
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/add-uuids",
-        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/add-harvesting-tag",
         "nextIndex": "6"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/add-harvesting-tag",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
+        "nextIndex": "7"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/execute-diff-deletes",
-        "nextIndex": "7"
+        "nextIndex": "8"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/execute-diff-deletes",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/checking-urls",
-        "nextIndex": "8"
+        "nextIndex": "9"
       }
     ]
   },
@@ -82,18 +87,23 @@
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/add-uuids",
-        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/add-harvesting-tag",
         "nextIndex": "6"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/add-harvesting-tag",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
+        "nextIndex": "7"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/publishHarvestedTriplesWithDeletes",
-        "nextIndex": "7"
+        "nextIndex": "8"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/publishHarvestedTriplesWithDeletes",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/checking-urls",
-        "nextIndex": "8"
+        "nextIndex": "9"
       }
     ]
   },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -205,7 +205,7 @@ services:
     logging: *default-logging
 
   harvest_sameas:
-    image: lblod/import-with-sameas-service:3.1.1
+    image: lblod/import-with-sameas-service:3.2.0-beta.1
     environment:
       RENAME_DOMAIN: "http://data.lblod.info/id/"
       TARGET_GRAPH: "http://mu.semte.ch/graphs/public"


### PR DESCRIPTION
This PR includes a new task for an `add-harvesting-tag` operation. It adds a provenance triple on every subject. This allows us to track the harvested data more easily in consuming applications.