### PR TITLE
Vendor provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## Unreleased
+ - added provenance tag
+ - bumped a lot of services
+### deploy notes
+Since virtuoso has been bumped; you will have to follow the upgrade path.
+See: https://github.com/redpencilio/docker-virtuoso/blob/dec36bd4a5ed4191c42e0a9b5ca979d67bc22cfe/README.md#upgrading
+Note: probably in our context; we'll be making a full flush; as we need to harvest everything from scratch.
 ## 0.15.2 (2023-07-25)
 - remove default mu-allowed-headers
 ## 0.15.1 (2023-07-25)

--- a/config/delta-producer/publication-graph-maintainer/worship/export.json
+++ b/config/delta-producer/publication-graph-maintainer/worship/export.json
@@ -27,7 +27,8 @@
         "http://www.w3.org/ns/prov#wasGeneratedBy",
         "http://data.lblod.info/vocabularies/contacthub/startdatum",
         "http://data.lblod.info/vocabularies/contacthub/eindedatum",
-        "http://www.w3.org/ns/org#heldBy"
+        "http://www.w3.org/ns/org#heldBy",
+        "http://www.w3.org/ns/prov#wasAssociatedWith"
       ]
     },
     {
@@ -44,7 +45,8 @@
         "http://data.lblod.info/vocabularies/contacthub/eindedatum",
         "http://www.w3.org/ns/org#heldBy",
         "http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan",
-        "http://schema.org/contactPoint"
+        "http://schema.org/contactPoint",
+        "http://www.w3.org/ns/prov#wasAssociatedWith"
       ]
     },
     {
@@ -63,7 +65,8 @@
         "http://www.w3.org/ns/adms#identifier",
         "http://data.vlaanderen.be/ns/mandaat#isAangesteldAls",
         "http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan",
-        "https://data.vlaanderen.be/ns/persoon#heeftNationaliteit"
+        "https://data.vlaanderen.be/ns/persoon#heeftNationaliteit",
+        "http://www.w3.org/ns/prov#wasAssociatedWith"
       ]
     },
     {
@@ -77,7 +80,8 @@
         "http://www.w3.org/2004/02/skos/core#notation",
         "http://purl.org/dc/terms/creator",
         "http://www.w3.org/ns/adms#schemaAgency",
-        "http://purl.org/dc/terms/issued"
+        "http://purl.org/dc/terms/issued",
+        "http://www.w3.org/ns/prov#wasAssociatedWith"
       ]
     },
     {
@@ -89,7 +93,8 @@
         "http://www.w3.org/ns/prov#wasGeneratedBy",
         "https://data.vlaanderen.be/ns/generiek#lokaleIdentificator",
         "https://data.vlaanderen.be/ns/generiek#naamruimte",
-        "https://data.vlaanderen.be/ns/generiek#versieIdentificator"
+        "https://data.vlaanderen.be/ns/generiek#versieIdentificator",
+        "http://www.w3.org/ns/prov#wasAssociatedWith"
       ]
     },
     {
@@ -99,7 +104,8 @@
         "http://mu.semte.ch/vocabularies/core/uuid",
         "http://www.w3.org/2002/07/owl#sameAs",
         "http://www.w3.org/ns/prov#wasGeneratedBy",
-        "https://data.vlaanderen.be/ns/persoon#datum"
+        "https://data.vlaanderen.be/ns/persoon#datum",
+        "http://www.w3.org/ns/prov#wasAssociatedWith"
       ]
     },
     {
@@ -122,7 +128,8 @@
         "http://xmlns.com/foaf/0.1/familyName",
         "http://schema.org/contactType",
         "http://mu.semte.ch/vocabularies/ext/secondaryContactPoint",
-        "http://schema.org/contactPoint"
+        "http://schema.org/contactPoint",
+        "http://www.w3.org/ns/prov#wasAssociatedWith"
       ]
     },
     {
@@ -153,7 +160,8 @@
         "https://data.vlaanderen.be/ns/adres#gemeentenaam",
         "https://data.vlaanderen.be/ns/adres#land",
         "http://data.lblod.info/vocabularies/leidinggevenden/adresRegisterId",
-        "https://data.vlaanderen.be/ns/adres#verwijstNaar"
+        "https://data.vlaanderen.be/ns/adres#verwijstNaar",
+        "http://www.w3.org/ns/prov#wasAssociatedWith"
       ]
     }
   ]

--- a/config/job-controller/config.json
+++ b/config/job-controller/config.json
@@ -38,18 +38,23 @@
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/add-harvesting-tag",
-        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/add-vendor-tag",
         "nextIndex": "7"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/add-vendor-tag",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
+        "nextIndex": "8"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/execute-diff-deletes",
-        "nextIndex": "8"
+        "nextIndex": "9"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/execute-diff-deletes",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/checking-urls",
-        "nextIndex": "9"
+        "nextIndex": "10"
       }
     ]
   },
@@ -92,18 +97,23 @@
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/add-harvesting-tag",
-        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/add-vendor-tag",
         "nextIndex": "7"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/add-vendor-tag",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
+        "nextIndex": "8"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/publishHarvestedTriplesWithDeletes",
-        "nextIndex": "8"
+        "nextIndex": "9"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/publishHarvestedTriplesWithDeletes",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/checking-urls",
-        "nextIndex": "9"
+        "nextIndex": "10"
       }
     ]
   },

--- a/config/resources/master-job-domain.lisp
+++ b/config/resources/master-job-domain.lisp
@@ -1,44 +1,37 @@
 (define-resource job ()
   :class (s-prefix "cogs:Job")
-  :properties `((:created :datetime ,(s-prefix "dct:created"))
-                (:modified :datetime ,(s-prefix "dct:modified"))
-                (:creator :url ,(s-prefix "dct:creator")) ;;Later consider using proper relation in domain.lisp
-                (:status :url ,(s-prefix "adms:status")) ;;Later consider using proper relation in domain.lisp
-                (:operation :url ,(s-prefix "task:operation")) ;;Later consider using proper relation in domain.lisp
-                (:comment :string ,(s-prefix "skos:comment")))
-
+  :properties `((:created   :datetime ,(s-prefix "dct:created"))
+                (:modified  :datetime ,(s-prefix "dct:modified"))
+                (:creator   :url      ,(s-prefix "dct:creator")) ;;Later consider using proper relation in domain.lisp
+                (:status    :url      ,(s-prefix "adms:status")) ;;Later consider using proper relation in domain.lisp
+                (:operation :url      ,(s-prefix "task:operation")) ;;Later consider using proper relation in domain.lisp
+                (:comment   :string   ,(s-prefix "skos:comment")))
   :has-one `((job-error :via ,(s-prefix "task:error")
                         :as "error"))
-
   :has-many `((task :via ,(s-prefix "dct:isPartOf")
                     :inverse t
                     :as "tasks"))
-
   :resource-base (s-url "http://redpencil.data.gift/id/job/")
   :features '(include-uri)
   :on-path "jobs")
 
 (define-resource task ()
   :class (s-prefix "task:Task")
-  :properties `((:created :datetime ,(s-prefix "dct:created"))
-                (:modified :datetime ,(s-prefix "dct:modified"))
-                (:status :url ,(s-prefix "adms:status")) ;;Later consider using proper relation in domain.lisp
-                (:operation :url ,(s-prefix "task:operation")) ;;Later consider using proper relation in domain.lisp
-                (:index :string ,(s-prefix "task:index")))
-
+  :properties `((:created   :datetime ,(s-prefix "dct:created"))
+                (:modified  :datetime ,(s-prefix "dct:modified"))
+                (:status    :url      ,(s-prefix "adms:status")) ;;Later consider using proper relation in domain.lisp
+                (:operation :url      ,(s-prefix "task:operation")) ;;Later consider using proper relation in domain.lisp
+                (:index     :string   ,(s-prefix "task:index")))
   :has-one `((job-error :via ,(s-prefix "task:error")
-                    :as "error")
+                        :as "error")
              (job :via ,(s-prefix "dct:isPartOf")
-                    :as "job"))
-
+                  :as "job"))
   :has-many `((task :via ,(s-prefix "cogs:dependsOn")
                     :as "parent-tasks")
               (data-container :via ,(s-prefix "task:resultsContainer")
-                    :as "results-containers")
+                              :as "results-containers")
               (data-container :via ,(s-prefix "task:inputContainer")
-                    :as "input-containers")
-              )
-
+                              :as "input-containers"))
   :resource-base (s-url "http://redpencil.data.gift/id/task/")
   :features '(include-uri)
   :on-path "tasks")
@@ -62,8 +55,7 @@
                     :as "result-from-tasks")
               (task :via ,(s-prefix "task:inputContainer")
                     :inverse t
-                    :as "input-from-tasks")
-              )
+                    :as "input-from-tasks"))
   :resource-base (s-url "http://redpencil.data.gift/id/dataContainers/")
   :features '(include-uri)
   :on-path "data-containers")

--- a/config/resources/master-job-domain.lisp
+++ b/config/resources/master-job-domain.lisp
@@ -5,7 +5,8 @@
                 (:creator   :url      ,(s-prefix "dct:creator")) ;;Later consider using proper relation in domain.lisp
                 (:status    :url      ,(s-prefix "adms:status")) ;;Later consider using proper relation in domain.lisp
                 (:operation :url      ,(s-prefix "task:operation")) ;;Later consider using proper relation in domain.lisp
-                (:comment   :string   ,(s-prefix "skos:comment")))
+                (:comment   :string   ,(s-prefix "skos:comment"))
+                (:vendor    :url      ,(s-prefix "prov:wasAssociatedWith")))
   :has-one `((job-error :via ,(s-prefix "task:error")
                         :as "error"))
   :has-many `((task :via ,(s-prefix "dct:isPartOf")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     logging: *default-logging
 
   frontend:
-    image: lblod/frontend-harvesting-self-service:2.1.5
+    image: lblod/frontend-harvesting-self-service:2.2.0
     volumes:
       - ./config/frontend:/config
     labels:
@@ -202,7 +202,7 @@ services:
     logging: *default-logging
 
   harvest_sameas:
-    image: lblod/import-with-sameas-service:4.1.1
+    image: lblod/import-with-sameas-service:4.2.0
     environment:
       RENAME_DOMAIN: "http://data.lblod.info/id/"
       TARGET_GRAPH: "http://mu.semte.ch/graphs/public"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     logging: *default-logging
 
   virtuoso:
-    image: redpencil/virtuoso:1.1.0
+    image: redpencil/virtuoso:1.2.0-rc.1
     environment:
       SPARQL_UPDATE: "true"
       DEFAULT_GRAPH: "http://mu.semte.ch/graphs/public"


### PR DESCRIPTION
In this PR, we want to add another task in the harvest workflow. This task adds a vendor URI to all subjects of the harvested data, similar to the already existing harvesting provenance tag. For this, we also add a new field on the Job model, because we initially set this vendor tag via the frontend.

**TODO:** more config changes are needed to add the tag to the produced delta files.