### PR TITLE
Vendor provenance 2

### DIFF
--- a/config/resources/master-scheduled-domain.lisp
+++ b/config/resources/master-scheduled-domain.lisp
@@ -1,46 +1,38 @@
 (define-resource scheduled-job ()
   :class (s-prefix "cogs:ScheduledJob")
-  :properties `((:creator :url ,(s-prefix "dct:creator"))
-                (:created :datetime ,(s-prefix "dct:created"))
-                (:modified :datetime ,(s-prefix "dct:modified"))
-                (:operation :url ,(s-prefix "task:operation"))
-                (:title :string ,(s-prefix "dct:title"))) ;;Later consider using proper relation in domain.lisp 
-
+  :properties `((:creator   :url      ,(s-prefix "dct:creator"))
+                (:created   :datetime ,(s-prefix "dct:created"))
+                (:modified  :datetime ,(s-prefix "dct:modified"))
+                (:operation :url      ,(s-prefix "task:operation"))
+                (:title     :string   ,(s-prefix "dct:title"))) ;;Later consider using proper relation in domain.lisp
   :has-one `((cron-schedule :via ,(s-prefix "task:schedule")
-                    :as "schedule"))
-
+                            :as "schedule"))
   :has-many `((scheduled-task :via ,(s-prefix "dct:isPartOf")
-                    :inverse t
-                    :as "scheduled-tasks"))
-
+                              :inverse t
+                              :as "scheduled-tasks"))
   :resource-base (s-url "http://redpencil.data.gift/id/scheduled-job/")
   :features '(include-uri)
   :on-path "scheduled-jobs")
 
 (define-resource scheduled-task ()
   :class (s-prefix "task:ScheduledTask")
-  :properties `((:created :datetime ,(s-prefix "dct:created"))
-                (:modified :datetime ,(s-prefix "dct:modified"))
-                (:operation :url ,(s-prefix "task:operation")) ;;Later consider using proper relation in domain.lisp
-                (:index :string ,(s-prefix "task:index")))
-
+  :properties `((:created   :datetime ,(s-prefix "dct:created"))
+                (:modified  :datetime ,(s-prefix "dct:modified"))
+                (:operation :url      ,(s-prefix "task:operation")) ;;Later consider using proper relation in domain.lisp
+                (:index     :string   ,(s-prefix "task:index")))
   :has-one `((scheduled-job :via ,(s-prefix "dct:isPartOf")
-                    :as "scheduled-job"))
-
+                            :as "scheduled-job"))
   :has-many `((scheduled-task :via ,(s-prefix "cogs:dependsOn")
-                    :as "parent-tasks")
+                              :as "parent-tasks")
               (data-container :via ,(s-prefix "task:inputContainer")
-                    :as "input-containers"))
-
+                              :as "input-containers"))
   :resource-base (s-url "http://redpencil.data.gift/id/scheduled-task/")
   :features '(include-uri)
   :on-path "scheduled-tasks")
 
-
 (define-resource cron-schedule ()
   :class (s-prefix "task:CronSchedule")
   :properties `((:repeat-frequency :string ,(s-prefix "schema:repeatFrequency")))
-
   :resource-base (s-url "http://redpencil.data.gift/id/cron-schedule/")
   :features '(include-uri)
   :on-path "cron-schedules")

--- a/config/resources/master-scheduled-domain.lisp
+++ b/config/resources/master-scheduled-domain.lisp
@@ -4,7 +4,8 @@
                 (:created   :datetime ,(s-prefix "dct:created"))
                 (:modified  :datetime ,(s-prefix "dct:modified"))
                 (:operation :url      ,(s-prefix "task:operation"))
-                (:title     :string   ,(s-prefix "dct:title"))) ;;Later consider using proper relation in domain.lisp
+                (:title     :string   ,(s-prefix "dct:title")) ;;Later consider using proper relation in domain.lisp
+                (:vendor    :url      ,(s-prefix "prov:wasAssociatedWith")))
   :has-one `((cron-schedule :via ,(s-prefix "task:schedule")
                             :as "schedule"))
   :has-many `((scheduled-task :via ,(s-prefix "dct:isPartOf")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -224,7 +224,7 @@ services:
     logging: *default-logging
 
   scheduled-job-controller:
-    image: lblod/scheduled-job-controller-service:1.0.2
+    image: lblod/scheduled-job-controller-service:1.1.0
     environment:
       # NOTE: if the delta-events prove to inaccurate,
       # you can go back to previous behavior by commenting out env.var. below


### PR DESCRIPTION
In the previous PRs about vendor provenance, the scheduled jobs where forgotten. This PR adds the necessary resource config and versions of related services.

[DL-5590]