### PR TITLE
Hotfix: filtering SHACL too restrictive

### DIFF
--- a/config/shacl/application-profile.ttl
+++ b/config/shacl/application-profile.ttl
@@ -13,7 +13,7 @@
     sh:description "Datum voor het einde van de aanstelling als mandataris" ;
     sh:path <http://data.lblod.info/vocabularies/erediensten/geplandeEinddatumAanstelling> ;
     sh:nodeKind sh:Literal ;
-    sh:datatype xsd:dateTime ;
+    sh:datatype xsd:date ;
     sh:minCount 0 ;
     sh:maxCount 1 ;
   ] ;

--- a/config/shacl/application-profile.ttl
+++ b/config/shacl/application-profile.ttl
@@ -66,7 +66,8 @@
     sh:name "Vervult" ;
     sh:description "Welk Mandataris deze Eredienst Mandataris vervult" ;
     sh:path <http://www.w3.org/ns/org#holds> ;
-    sh:class <http://data.vlaanderen.be/ns/mandaat#Mandataris> ;
+    #The following is correct, but in this database, there is no information about Mandatarissen. That is only in Loket.
+    #sh:class <http://data.vlaanderen.be/ns/mandaat#Mandataris> ;
     sh:nodeKind sh:IRI ;
     sh:minCount 1 ;
     sh:maxCount 1 ;

--- a/config/shacl/application-profile.ttl
+++ b/config/shacl/application-profile.ttl
@@ -106,15 +106,6 @@
     sh:datatype xsd:dateTime ;
     sh:minCount 0 ;
     sh:maxCount 1 ;
-  ] ;
-  sh:property [
-    sh:name "Vervult door" ;
-    sh:description "Persoon die deze mandataris vervult" ;
-    sh:path <http://www.w3.org/ns/org#heldBy> ;
-    sh:class <http://www.w3.org/ns/person#Person> ;
-    sh:nodeKind sh:IRI ;
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
   ] .
 
 <https://data.vlaanderen.be/shacl/erediensten#RolBedienaarShape>

--- a/config/shacl/application-profile.ttl
+++ b/config/shacl/application-profile.ttl
@@ -12,7 +12,6 @@
     sh:name "Einddatum voor aanstelling" ;
     sh:description "Datum voor het einde van de aanstelling als mandataris" ;
     sh:path <http://data.lblod.info/vocabularies/erediensten/geplandeEinddatumAanstelling> ;
-    sh:class <> ;
     sh:nodeKind sh:Literal ;
     sh:datatype xsd:dateTime ;
     sh:minCount 0 ;


### PR DESCRIPTION
The SHACL profile was not properly tested or was tested against QA data that is different from production data. There were some issues with it ranging from typos to wrong datatypes and unavailability of type information.

These are fixed with this PR and tested against production data. There are still some errors in the data but they really are mistakes (e.g. a position with two different start dates and such). Check the commits for a more detailed explanation of the implemented corrections.