### PR TITLE
Fix: `import-with-sameas-service` faulty file splits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## Unreleased
+ - Bump `import-with-sameas-service`: fix broken harvests due to splitting files when streaming triples. This was only a (visible) problem when harvesters started from scatch (when there is no information about mirrors in the triplestore yet).
 ## 0.16.3 (2024-02-23)
  - Hotfix: SHACL profile was too restrictive and had some typographic and logical problems concerning production data for EredienstMandatarissen positions.
 ## 0.16.2 (2024-02-09)

--- a/config/same-as-service/config.json
+++ b/config/same-as-service/config.json
@@ -1,4 +1,5 @@
-{"known-domains": [
+{
+  "known-domains": [
     "data.lblod.info",
     "data.vlaanderen.be",
     "mu.semte.ch",
@@ -11,6 +12,9 @@
     "schema.org",
     "centrale-vindplaats.lblod.info",
     "publications.europa.eu"
+  ],
+  "predicates-to-ignore": [
+    "http://www.w3.org/ns/prov#wasDerivedFrom"
   ],
   "protocols-to-rename": [
     "http:",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -202,7 +202,7 @@ services:
     logging: *default-logging
 
   harvest_sameas:
-    image: lblod/import-with-sameas-service:4.3.0
+    image: lblod/import-with-sameas-service:4.3.1
     environment:
       RENAME_DOMAIN: "http://data.lblod.info/id/"
       TARGET_GRAPH: "http://mu.semte.ch/graphs/public"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -202,7 +202,7 @@ services:
     logging: *default-logging
 
   harvest_sameas:
-    image: lblod/import-with-sameas-service:4.2.0
+    image: lblod/import-with-sameas-service:4.3.0
     environment:
       RENAME_DOMAIN: "http://data.lblod.info/id/"
       TARGET_GRAPH: "http://mu.semte.ch/graphs/public"


### PR DESCRIPTION
Bump to latest version of the `import-with-sameas-service` to benefit from crucial bug fixes and include some missing config.

See https://github.com/lblod/import-with-sameas-service/pull/29