### PR TITLE
Fix: Too many deletes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,7 +191,8 @@ services:
     logging: *default-logging
 
   harvest_diff:
-    image: lblod/harvesting-diff-service:0.2.0
+    #image: lblod/harvesting-diff-service:0.2.0
+    image: lblod/harvesting-diff-service:feature-get-only-previous-input
     environment:
       TARGET_GRAPH: "http://mu.semte.ch/graphs/harvesting"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -203,7 +203,7 @@ services:
     logging: *default-logging
 
   harvest_sameas:
-    image: lblod/import-with-sameas-service:4.3.1
+    image: lblod/import-with-sameas-service:4.4.0
     environment:
       RENAME_DOMAIN: "http://data.lblod.info/id/"
       TARGET_GRAPH: "http://mu.semte.ch/graphs/public"


### PR DESCRIPTION
**[DL-5819]**

After a while on the production harvester, we noticed a terrible amount of deleted data. More deleted data than was inserted and more deleted data than was actually in the triplestore!

This was caused by the harvesting-diff-service that would accumulate all data from all the existing previous jobs to calculate the diffs. This wouldn't be a problem, except that on some days, half of the harvested data went missing and a lot of subjects got removed. When they where reintroduced, the import-with-sameas-service would create entirely new mirrored URIs for those subjects. Repeating this a couple of times and you end up with a constant +80MB of deletes per harvest and +60MB of inserts on days the missing subjects are reintroduced.

These issues where solved by:

* using hashes in the import-with-sameas-service during the mirroring for creating a new URI. The new URI is based on the old version and will always be the same. See https://github.com/lblod/import-with-sameas-service/pull/30
* The diff service now only looks at the previous successful Job and diff Task for the state of the triplestore. See https://github.com/lblod/harvesting-diff-service/tree/feature/get-only-previous-input