### PR TITLE
[DL-6795]: Upgrade to acm/idm for authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,47 @@
 # Changelog
+## Unreleased
+- Upgrade to acm/idm for authentication (DL-6795)
+
+### Deploy instructions
+
+#### DEV
+Dev will remain using the mu-login, so in the `docker-compose.override.yml`:
+```
+  frontend:
+    environment:
+      EMBER_LOGIN_ROUTE: "login"
+
+  login:
+    image: semtech/mu-login-service:3.0.0
+    environment:
+      USERS_GRAPH: "http://mu.semte.ch/graphs/users"
+      SESSIONS_GRAPH: "http://mu.semte.ch/graphs/sessions"
+```
+
+#### QA
+`docker-compose.override.yml`:
+```
+  frontend:
+    environment:
+      EMBER_AUTHENTICATION_ENABLED: 'true'
+      EMBER_LOGIN_ROUTE: "acmidm-login"
+      EMBER_ACMIDM_CLIENT_ID: "fe47a486-1cec-421d-a6d1-c7df1d35e3e4"
+      EMBER_ACMIDM_BASE_URL: "https://authenticatie-ti.vlaanderen.be/op/v1/auth"
+      EMBER_ACMIDM_REDIRECT_URL: "https://worship-harvester.lblod.info/authorization/callback"
+      EMBER_ACMIDM_LOGOUT_URL: "https://authenticatie-ti.vlaanderen.be/op/v1/logout"
+
+  login:
+    environment:
+      MU_APPLICATION_AUTH_DISCOVERY_URL: "https://authenticatie-ti.vlaanderen.be/op"
+      MU_APPLICATION_AUTH_CLIENT_ID: "fe47a486-1cec-421d-a6d1-c7df1d35e3e4"
+      MU_APPLICATION_AUTH_REDIRECT_URI: "https://worship-harvester.lblod.info/authorization/callback"
+      MU_APPLICATION_AUTH_CLIENT_SECRET: "snip" # see ticket for secret
+```
+
+#### PROD
+
+Configure the environment variables for the PROD ACM/IDM environment once the values are known.
+
 ## 0.16.11 (2024-08-19)
  - Add missing `restart: always` for `login`. (DL-6103)
 ## 0.16.10 (2024-07-19)

--- a/README.md
+++ b/README.md
@@ -70,21 +70,27 @@ delta-producer-publication-graph-maintainer-worship:
 This app allows you to add authentication fields to both the Job and Scheduled
 Job request. To protect the app from unauthorized access via the frontend and
 API, you need to be authenticated. To configure authentication, you need to add
-an environment variable to the `frontend-harvester-self-service` and update the
+an environment variable to the `frontend-harvesting-self-service` and update the
 mu-authorization config. This should all be in place for this repository, no
 work needed. Having authentication is the main difference between this
 repository and the regular harvester.
 
-### Create login user (all environments)
+### DEV: mu-login
 
-For now, we use specific logins for the dashboard users. Each environment has
-its own password. To add a user, make sure to have installed
+The DEV environment uses mu-login for authentication. To add a mu-login user, make sure to have installed
 [mu-cli](https://github.com/mu-semtech/mu-cli) first. Then in
 `docker-compose.override.yml` add:
 
 ```yaml
-dashboard-login
+frontend:
   environment:
+    EMBER_LOGIN_ROUTE: "login"
+
+login:
+  image: semtech/mu-login-service:3.0.0
+  environment:
+    USERS_GRAPH: "http://mu.semte.ch/graphs/users"
+    SESSIONS_GRAPH: "http://mu.semte.ch/graphs/sessions"
     MU_APPLICATION_SALT: 'a_random_string_with_sufficient_entropy'
 ```
 
@@ -93,8 +99,12 @@ project-scripts generate-dashboard-login` and following the steps. Restart
 `migrations`, wait for them to finish and you can use the account you created
 to login.
 
-Note: on DEV and QA, the passwords will be kept in on the server in
+Note: on DEV, the password will be kept on the server in
 `docker-compose.override.yml`
+
+### QA & PROD: ACM/IDM
+
+The QA and PROD environments use acm/idm for the authentication. Request access rights internally if needed.
 
 ## Additional notes
 
@@ -122,4 +132,3 @@ repository](https://github.com/lblod/delta-producer-report-generator).
 
 Should have credentials provided, see [the deliver-email-service
 repository](https://github.com/redpencilio/deliver-email-service).
-

--- a/config/migrations/2025/20251010144130-add-bestuurseenheid-abb.sparql
+++ b/config/migrations/2025/20251010144130-add-bestuurseenheid-abb.sparql
@@ -1,0 +1,13 @@
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> a besluit:Bestuurseenheid ;
+       mu:uuid "141d9d6b-54af-4d17-b313-8d1c30bc3f5b" ;
+       skos:prefLabel "Agentschap Binnenlands Bestuur" ;
+       dcterms:identifier "OVO001835" .
+  }
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -17,6 +17,8 @@ services:
     restart: "no"
 
   virtuoso:
+    ports:
+      - "8890:8890"
     restart: "no"
 
   migrations:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     logging: *default-logging
 
   frontend:
-    image: lblod/frontend-harvesting-self-service:feature-acmidm-login
+    image: lblod/frontend-harvesting-self-service:2.6.0
     volumes:
       - ./config/frontend:/config
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     logging: *default-logging
 
   frontend:
-    image: lblod/frontend-harvesting-self-service:2.2.0
+    image: lblod/frontend-harvesting-self-service:feature-acmidm-login
     volumes:
       - ./config/frontend:/config
     labels:
@@ -42,7 +42,12 @@ services:
       EMBER_AUTHENTICATION_ENABLED: "true"
       EMBER_BESLUITEN_HARVESTING_ENABLED: "false"
       EMBER_WORSHIP_HARVESTING_ENABLED: "true"
-
+      EMBER_LOGIN_ROUTE: "acmidm-login"
+      EMBER_ACMIDM_CLIENT_ID: "<CLIENT_ID>"
+      EMBER_ACMIDM_BASE_URL: "<BASE_URL>"
+      EMBER_ACMIDM_REDIRECT_URL: "<REDIRECT_URL>"
+      EMBER_ACMIDM_LOGOUT_URL: "<LOGOUT_URL>"
+      EMBER_ACMIDM_SCOPE: "openid rrn vo profile abb_eredienstenharvester"
   database:
     image: semtech/mu-authorization:0.6.0-beta.8
     environment:
@@ -119,10 +124,14 @@ services:
     logging: *default-logging
 
   login:
-    image: semtech/mu-login-service:3.0.0
+    image: lblod/acmidm-login-service:0.12.0
     environment:
-      USERS_GRAPH: "http://mu.semte.ch/graphs/users"
-      SESSIONS_GRAPH: "http://mu.semte.ch/graphs/sessions"
+      DEBUG_LOG_TOKENSETS: true
+      MU_APPLICATION_AUTH_ROLE_CLAIM: "abb_eredienstenharvester_3d"
+      MU_APPLICATION_AUTH_DISCOVERY_URL: "<ACM_IDM_AUTH_DISCOVERY_URL>"
+      MU_APPLICATION_AUTH_CLIENT_ID: "<ACM_IDM_AUTH_CLIENT_ID>"
+      MU_APPLICATION_AUTH_REDIRECT_URI: "<ACMIDM_AUTH_REDIRECT_URI>"
+      MU_APPLICATION_AUTH_CLIENT_SECRET: "<ACMIDM_AUTH_CLIENT_SECRET>"
     logging: *default-logging
     restart: always
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,7 +127,7 @@ services:
     image: lblod/acmidm-login-service:0.12.0
     environment:
       DEBUG_LOG_TOKENSETS: true
-      MU_APPLICATION_AUTH_ROLE_CLAIM: "abb_eredienstenharvester_3d"
+      MU_APPLICATION_AUTH_ROLE_CLAIM: "abb_eredienstenharvester_rol_1d"
       MU_APPLICATION_AUTH_DISCOVERY_URL: "<ACM_IDM_AUTH_DISCOVERY_URL>"
       MU_APPLICATION_AUTH_CLIENT_ID: "<ACM_IDM_AUTH_CLIENT_ID>"
       MU_APPLICATION_AUTH_REDIRECT_URI: "<ACMIDM_AUTH_REDIRECT_URI>"


### PR DESCRIPTION
This PR upgrades to use ACM/IDM, but for DEV we will still use the mu-login.

### Test instructionsz

1. Set up your `/etc/hosts`

Add the following line to the file:
```
127.0.0.1 worship-harvester.lblod.info
```

2. Set up Caddy in your app

Add the following to your `docker-compose.override.yml`:
```yml
  # use this to test acmidm
  tlsproxy:
    image: caddy:2
    ports:
      - "443:443"
    environment:
      APPLICATION_ADDRESS: "worship-harvester.lblod.info"
    volumes:
      - ./config/tlsproxy-mock/Caddyfile:/etc/caddy/Caddyfile
    restart: "no"
```

and the following file as config, names `config/tlsproxy-mock/Caddyfile`:

```
https://{$APPLICATION_ADDRESS} {
  reverse_proxy identifier:80
  tls internal
}
```

3. Add the QA ACM/IDM environment variables to the dashboard and dashboard-login services.

<details>
<summary>QA Environment variables</summary>

```yml
# docker-compose.override.yml
  frontend:
    environment:
      EMBER_AUTHENTICATION_ENABLED: 'true'
      EMBER_LOGIN_ROUTE: "acmidm-login"
      EMBER_ACMIDM_CLIENT_ID: "fe47a486-1cec-421d-a6d1-c7df1d35e3e4"
      EMBER_ACMIDM_BASE_URL: "https://authenticatie-ti.vlaanderen.be/op/v1/auth"
      EMBER_ACMIDM_REDIRECT_URL: "https://worship-harvester.lblod.info/authorization/callback"
      EMBER_ACMIDM_LOGOUT_URL: "https://authenticatie-ti.vlaanderen.be/op/v1/logout"

  login:
    environment:
      MU_APPLICATION_AUTH_DISCOVERY_URL: "https://authenticatie-ti.vlaanderen.be/op"
      MU_APPLICATION_AUTH_CLIENT_ID: "fe47a486-1cec-421d-a6d1-c7df1d35e3e4"
      MU_APPLICATION_AUTH_REDIRECT_URI: "https://worship-harvester.lblod.info/authorization/callback"
      MU_APPLICATION_AUTH_CLIENT_SECRET: "snip" # see ticket for secret
```
</details>

4. You're ready to go :)

Going to `APPLICATION_ADDRESS` in your browser should now give an error when your stack is down, and should show the app when the stack is up. You should then be able to log in as if you were on qa.
