### PR TITLE
Feature/more provenance on changed subjects

### DIFF
--- a/config/delta-producer/publication-graph-maintainer/worship/export.json
+++ b/config/delta-producer/publication-graph-maintainer/worship/export.json
@@ -28,7 +28,9 @@
         "http://data.lblod.info/vocabularies/contacthub/startdatum",
         "http://data.lblod.info/vocabularies/contacthub/eindedatum",
         "http://www.w3.org/ns/org#heldBy",
-        "http://www.w3.org/ns/prov#wasAssociatedWith"
+        "http://www.w3.org/ns/prov#wasAssociatedWith",
+        "http://redpencil.data.gift/vocabularies/tasks/modifiedOn",
+        "http://redpencil.data.gift/vocabularies/tasks/modifiedBy"
       ]
     },
     {
@@ -46,7 +48,9 @@
         "http://www.w3.org/ns/org#heldBy",
         "http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan",
         "http://schema.org/contactPoint",
-        "http://www.w3.org/ns/prov#wasAssociatedWith"
+        "http://www.w3.org/ns/prov#wasAssociatedWith",
+        "http://redpencil.data.gift/vocabularies/tasks/modifiedOn",
+        "http://redpencil.data.gift/vocabularies/tasks/modifiedBy"
       ]
     },
     {
@@ -66,7 +70,9 @@
         "http://data.vlaanderen.be/ns/mandaat#isAangesteldAls",
         "http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan",
         "https://data.vlaanderen.be/ns/persoon#heeftNationaliteit",
-        "http://www.w3.org/ns/prov#wasAssociatedWith"
+        "http://www.w3.org/ns/prov#wasAssociatedWith",
+        "http://redpencil.data.gift/vocabularies/tasks/modifiedOn",
+        "http://redpencil.data.gift/vocabularies/tasks/modifiedBy"
       ]
     },
     {
@@ -81,7 +87,9 @@
         "http://purl.org/dc/terms/creator",
         "http://www.w3.org/ns/adms#schemaAgency",
         "http://purl.org/dc/terms/issued",
-        "http://www.w3.org/ns/prov#wasAssociatedWith"
+        "http://www.w3.org/ns/prov#wasAssociatedWith",
+        "http://redpencil.data.gift/vocabularies/tasks/modifiedOn",
+        "http://redpencil.data.gift/vocabularies/tasks/modifiedBy"
       ]
     },
     {
@@ -94,7 +102,9 @@
         "https://data.vlaanderen.be/ns/generiek#lokaleIdentificator",
         "https://data.vlaanderen.be/ns/generiek#naamruimte",
         "https://data.vlaanderen.be/ns/generiek#versieIdentificator",
-        "http://www.w3.org/ns/prov#wasAssociatedWith"
+        "http://www.w3.org/ns/prov#wasAssociatedWith",
+        "http://redpencil.data.gift/vocabularies/tasks/modifiedOn",
+        "http://redpencil.data.gift/vocabularies/tasks/modifiedBy"
       ]
     },
     {
@@ -105,7 +115,9 @@
         "http://www.w3.org/2002/07/owl#sameAs",
         "http://www.w3.org/ns/prov#wasGeneratedBy",
         "https://data.vlaanderen.be/ns/persoon#datum",
-        "http://www.w3.org/ns/prov#wasAssociatedWith"
+        "http://www.w3.org/ns/prov#wasAssociatedWith",
+        "http://redpencil.data.gift/vocabularies/tasks/modifiedOn",
+        "http://redpencil.data.gift/vocabularies/tasks/modifiedBy"
       ]
     },
     {
@@ -129,7 +141,9 @@
         "http://schema.org/contactType",
         "http://mu.semte.ch/vocabularies/ext/secondaryContactPoint",
         "http://schema.org/contactPoint",
-        "http://www.w3.org/ns/prov#wasAssociatedWith"
+        "http://www.w3.org/ns/prov#wasAssociatedWith",
+        "http://redpencil.data.gift/vocabularies/tasks/modifiedOn",
+        "http://redpencil.data.gift/vocabularies/tasks/modifiedBy"
       ]
     },
     {
@@ -161,7 +175,9 @@
         "https://data.vlaanderen.be/ns/adres#land",
         "http://data.lblod.info/vocabularies/leidinggevenden/adresRegisterId",
         "https://data.vlaanderen.be/ns/adres#verwijstNaar",
-        "http://www.w3.org/ns/prov#wasAssociatedWith"
+        "http://www.w3.org/ns/prov#wasAssociatedWith",
+        "http://redpencil.data.gift/vocabularies/tasks/modifiedOn",
+        "http://redpencil.data.gift/vocabularies/tasks/modifiedBy"
       ]
     }
   ]

--- a/config/diff/sparql/load-task.sparql
+++ b/config/diff/sparql/load-task.sparql
@@ -10,7 +10,7 @@ PREFIX oslc: <http://open-services.net/ns/core#>
 PREFIX cogs: <http://vocab.deri.ie/cogs#>
 PREFIX adms: <http://www.w3.org/ns/adms#>
 
-SELECT DISTINCT ?graph ?task ?id ?job ?created ?modified ?status ?index ?operation ?error WHERE {
+SELECT DISTINCT ?graph ?task ?id ?job ?jobId ?created ?modified ?status ?index ?operation ?error WHERE {
       GRAPH ?graph {
             BIND(<%s> as ?task)
             ?task a task:Task.
@@ -21,6 +21,7 @@ SELECT DISTINCT ?graph ?task ?id ?job ?created ?modified ?status ?index ?operati
                       adms:status ?status;
                       task:index ?index;
                       task:operation ?operation.
-                      OPTIONAL { ?task task:error ?error. }
+            ?job mu:uuid ?jobId.
+            OPTIONAL { ?task task:error ?error. }
       }
 }

--- a/config/job-controller/config.json
+++ b/config/job-controller/config.json
@@ -13,11 +13,11 @@
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting",
-        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/importing",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/extracting",
         "nextIndex": "2"
       },
       {
-        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/importing",
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/extracting",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/filtering",
         "nextIndex": "3"
       },
@@ -77,11 +77,11 @@
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting",
-        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/importing",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/extracting",
         "nextIndex": "2"
       },
       {
-        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/importing",
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/extracting",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/filtering",
         "nextIndex": "3"
       },

--- a/config/job-controller/config.json
+++ b/config/job-controller/config.json
@@ -48,13 +48,18 @@
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
-        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/execute-diff-deletes",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/tag-diff-modified",
         "nextIndex": "9"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/tag-diff-modified",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/execute-diff-deletes",
+        "nextIndex": "10"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/execute-diff-deletes",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/checking-urls",
-        "nextIndex": "10"
+        "nextIndex": "11"
       }
     ]
   },
@@ -107,13 +112,18 @@
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
-        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/publishHarvestedTriplesWithDeletes",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/tag-diff-modified",
         "nextIndex": "9"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/tag-diff-modified",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/publishHarvestedTriplesWithDeletes",
+        "nextIndex": "10"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/publishHarvestedTriplesWithDeletes",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/checking-urls",
-        "nextIndex": "10"
+        "nextIndex": "11"
       }
     ]
   },

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
 
   identifier:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 x-logging: &default-logging
   driver: "json-file"
   options:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,7 +145,7 @@ services:
     logging: *default-logging
 
   harvest_download-url:
-    image: lblod/download-url-service:1.0.3
+    image: lblod/download-url-service:1.3.0
     volumes:
       - ./data/files:/share
     environment:
@@ -177,7 +177,7 @@ services:
     logging: *default-logging
 
   harvest_import:
-    image: lblod/harvesting-import-service:0.13.3
+    image: lblod/harvesting-extract-to-ttl:0.15.0
     environment:
       TARGET_GRAPH: "http://mu.semte.ch/graphs/harvesting"
     volumes:
@@ -188,7 +188,7 @@ services:
     logging: *default-logging
 
   harvest_validate:
-    image: lblod/harvesting-validator:0.3.0
+    image: lblod/harvesting-validator:0.4.0
     environment:
       TARGET_GRAPH: "http://mu.semte.ch/graphs/harvesting"
       STRICT_MODE_FILTERING: "false"
@@ -201,6 +201,9 @@ services:
     logging: *default-logging
 
   harvest_diff:
+    # Sometimes the diff service does not find the task in the delta message.
+    # (2026-07-24)
+    # image: lblod/harvesting-diff-service:0.3.0
     image: lblod/harvesting-diff-service:0.2.3
     environment:
       TARGET_GRAPH: "http://mu.semte.ch/graphs/harvesting"
@@ -228,6 +231,9 @@ services:
     logging: *default-logging
 
   job-controller:
+    # A problem with the validate and diff service prevent the app from working
+    # with a more recent version of this service. (2026-07-24)
+    # image: lblod/job-controller-service:1.4.1
     image: lblod/job-controller-service:1.0.1
     volumes:
       - ./config/job-controller:/config
@@ -237,7 +243,7 @@ services:
     logging: *default-logging
 
   scheduled-job-controller:
-    image: lblod/scheduled-job-controller-service:1.1.0
+    image: lblod/scheduled-job-controller-service:1.3.0
     environment:
       # NOTE: if the delta-events prove to inaccurate,
       # you can go back to previous behavior by commenting out env.var. below
@@ -260,7 +266,7 @@ services:
     logging: *default-logging
 
   error-alert:
-    image: lblod/loket-error-alert-service:1.0.0
+    image: lblod/loket-error-alert-service:1.0.2
     volumes:
       - ./config/error-alert:/config/
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,7 +188,7 @@ services:
     logging: *default-logging
 
   harvest_validate:
-    image: lblod/harvesting-validator:0.4.0
+    image: lblod/harvesting-validator:0.4.1
     environment:
       TARGET_GRAPH: "http://mu.semte.ch/graphs/harvesting"
       STRICT_MODE_FILTERING: "false"
@@ -201,10 +201,7 @@ services:
     logging: *default-logging
 
   harvest_diff:
-    # Sometimes the diff service does not find the task in the delta message.
-    # (2026-07-24)
-    # image: lblod/harvesting-diff-service:0.3.0
-    image: lblod/harvesting-diff-service:0.2.3
+    image: lblod/harvesting-diff-service:0.3.1
     environment:
       TARGET_GRAPH: "http://mu.semte.ch/graphs/harvesting"
       SPARQL_QUERYSTORE_PATH: "file:/config/sparql"
@@ -231,10 +228,7 @@ services:
     logging: *default-logging
 
   job-controller:
-    # A problem with the validate and diff service prevent the app from working
-    # with a more recent version of this service. (2026-07-24)
-    # image: lblod/job-controller-service:1.4.1
-    image: lblod/job-controller-service:1.0.1
+    image: lblod/job-controller-service:1.4.1
     volumes:
       - ./config/job-controller:/config
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -214,7 +214,7 @@ services:
     logging: *default-logging
 
   harvest_sameas:
-    image: lblod/import-with-sameas-service:4.5.0
+    image: lblod/import-with-sameas-service:4.11.0
     environment:
       RENAME_DOMAIN: "http://data.lblod.info/id/"
       TARGET_GRAPH: "http://mu.semte.ch/graphs/public"


### PR DESCRIPTION
**[DL-7434] [DL-7435]**

Adding more provenance triples to subjects that have changed in the current harvesting job.

Every changed subjects (removals, inserts) gets 2 new triples:

```turtle
<subject> task:modifiedOn <now>^^xsd:dateTime .
<subject> task:modifiedBy <Job URI> .
```

Old values for these predicates are removed from the triplestore.

This data is also exported with the producer.